### PR TITLE
change platformtarget to AnyCPU

### DIFF
--- a/C#/Trivia/Trivia/Trivia.csproj
+++ b/C#/Trivia/Trivia/Trivia.csproj
@@ -30,7 +30,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>


### PR DESCRIPTION
This prevents getting a 'BadFormatException' when adding a test project on a 64bit machine