### PR TITLE
changes to reflect new RSpec expectation syntax & deprecated default config setting

### DIFF
--- a/ruby/spec/example_spec.rb
+++ b/ruby/spec/example_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe "example test" do
   it "should pass" do
-    true.should == true
+    expect(true).to eq(true)
   end
 end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
updated spec to reflect RSpec's New Expectation Syntax and removed deprecated default config setting