### PR TITLE
Update Clojure to use `deps.edn` with better testing tools

### DIFF
--- a/clojure/.clj-kondo/imports/com.github.seancorfield/expectations/config.edn
+++ b/clojure/.clj-kondo/imports/com.github.seancorfield/expectations/config.edn
@@ -1,0 +1,10 @@
+{:hooks
+ {:analyze-call
+  {expectations.clojure.test/more->
+   hooks.com.github.seancorfield.expectations/more->
+   expectations.clojure.test/more-of
+   hooks.com.github.seancorfield.expectations/more-of}}
+ :lint-as
+ {expectations.clojure.test/defexpect clojure.test/deftest
+  expectations.clojure.test/from-each clojure.core/for
+  expectations.clojure.test/=? clojure.core/=}}

--- a/clojure/.clj-kondo/imports/com.github.seancorfield/expectations/hooks/com/github/seancorfield/expectations.clj_kondo
+++ b/clojure/.clj-kondo/imports/com.github.seancorfield/expectations/hooks/com/github/seancorfield/expectations.clj_kondo
@@ -1,0 +1,29 @@
+(ns hooks.com.github.seancorfield.expectations
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn more-> [{:keys [node]}]
+  (let [tail (rest (:children node))
+        rewritten
+        (api/list-node
+         (list*
+          (api/token-node 'cond->)
+          (api/token-node 'nil)
+          tail))]
+    {:node rewritten}))
+
+(defn more-of [{:keys [node]}]
+  (let [bindings (fnext (:children node))
+        pairs (partition 2 (nnext (:children node)))
+        rewritten
+        (api/list-node
+         (list*
+          (api/token-node 'fn)
+          (api/vector-node (vector bindings))
+          (map (fn [[e a]]
+                 (api/list-node
+                  (list
+                   (api/token-node 'expectations.clojure.test/expect)
+                   e
+                   a)))
+               pairs)))]
+    {:node rewritten}))

--- a/clojure/.gitignore
+++ b/clojure/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+/.cpcache
+/.lsp
+/.clj-kondo/.cache
+/.nrepl-port

--- a/clojure/README.md
+++ b/clojure/README.md
@@ -1,0 +1,7 @@
+Trivia kata in Clojure
+=========================
+
+1. Run the game with this command: `clojure -M:run-game`
+2. Run the tests with this command: `clojure -M:test`
+3. Runt the test watcher with this command: `clojure -X:test:watch`
+

--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -2,7 +2,10 @@
  :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
 
  :aliases
- {:test
+ {:run-game
+  {:main-opts ["-m" "trivia.Gamerunner"]}
+
+  :test
   {:extra-deps  {lambdaisland/kaocha                  {:mvn/version "1.91.1392"}
                  com.github.seancorfield/expectations {:mvn/version "2.2.214"}}
    :extra-paths ["test"]

--- a/clojure/deps.edn
+++ b/clojure/deps.edn
@@ -1,0 +1,13 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.12.0"}}
+
+ :aliases
+ {:test
+  {:extra-deps  {lambdaisland/kaocha                  {:mvn/version "1.91.1392"}
+                 com.github.seancorfield/expectations {:mvn/version "2.2.214"}}
+   :extra-paths ["test"]
+   :main-opts   ["-m" "kaocha.runner"]}
+
+  :watch
+  {:exec-fn      kaocha.runner/exec-fn
+   :exec-args {:watch? true}}}}

--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -1,6 +1,0 @@
-(defproject trivia "0.1.0-SNAPSHOT"
-  :description "Clojure ugly trivia"
-  :dependencies [[org.clojure/clojure "1.8.0"]]
-  :main ^:skip-aot trivia.Gamerunner
-  :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}})

--- a/clojure/test/trivia/Game_test.clj
+++ b/clojure/test/trivia/Game_test.clj
@@ -1,0 +1,7 @@
+(ns trivia.Game-test
+  (:require
+   [trivia.Game :as sut]
+   [expectations.clojure.test :refer [defexpect expect]]))
+
+(defexpect example-test
+  (expect 1 1))

--- a/clojure/tests.edn
+++ b/clojure/tests.edn
@@ -1,0 +1,4 @@
+#kaocha/v1
+{:tests [{:id          :unit
+          :test-paths  ["test" "src"]
+          :ns-patterns [".*"]}]}


### PR DESCRIPTION
I updated the Clojure version of this kata to use newer tools.  I hope this promotes beginner-friendliness.

I swapped Leiningen for a `deps.edn` file.  I also added some aliases to make testing a little easier for people who are less familiar with Clojure. 

There's a `test` alias that adds testing dependencies and testing paths.

There's a `watch` alias, that uses exec-fn to run `kaocha` in watch mode.

There's a `run-game` alias, which runs the game.  

I also added a readme with directions for people who may not know how to run the code from reading `deps.edn`.